### PR TITLE
Allow a subject field to be passed to MailActivity.

### DIFF
--- a/REActivityViewController/REMailActivity.m
+++ b/REActivityViewController/REMailActivity.m
@@ -35,9 +35,11 @@
                           image:[UIImage imageNamed:@"REActivityViewController.bundle/Icon_Mail"]
                     actionBlock:^(REActivity *activity, REActivityViewController *activityViewController) {
                         NSDictionary *userInfo = activityViewController.userInfo;
+                        NSString *subject = [userInfo objectForKey:@"subject"];
                         NSString *text = [userInfo objectForKey:@"text"];
                         UIImage *image = [userInfo objectForKey:@"image"];
                         NSURL *url = [userInfo objectForKey:@"url"];
+                        
                         [activityViewController dismissViewControllerAnimated:YES completion:^{
                             MFMailComposeViewController *mailComposeViewController = [[MFMailComposeViewController alloc] init];
                             [REActivityDelegateObject sharedObject].controller = activityViewController.presentingController;
@@ -55,9 +57,12 @@
                             if (image)
                                 [mailComposeViewController addAttachmentData:UIImageJPEGRepresentation(image, 0.75f) mimeType:@"image/jpeg" fileName:@"photo.jpg"];
                             
+                            if (subject)
+                                [mailComposeViewController setSubject:subject];
+                            
                             [activityViewController.presentingController presentViewController:mailComposeViewController animated:YES completion:nil];
                         }];
-    }];
+                    }];
 }
 
 @end


### PR DESCRIPTION
Simply pass it along with url / text etc. as 'subject' when creating the
controller.

This is a very annoying limitation of the default UIActivityViewController.
