### PR TITLE
Normalization of generic weak references (academic fix)

### DIFF
--- a/REActivityViewController/REDiigoActivity.m
+++ b/REActivityViewController/REDiigoActivity.m
@@ -37,7 +37,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;
         [activityViewController dismissViewControllerAnimated:YES completion:^{

--- a/REActivityViewController/REFacebookActivity.m
+++ b/REActivityViewController/REFacebookActivity.m
@@ -37,7 +37,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         UIViewController *presenter = activityViewController.presentingController;
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;

--- a/REActivityViewController/REInstapaperActivity.m
+++ b/REActivityViewController/REInstapaperActivity.m
@@ -39,7 +39,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         UIViewController *presenter = activityViewController.presentingController;
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;

--- a/REActivityViewController/REMailActivity.m
+++ b/REActivityViewController/REMailActivity.m
@@ -39,7 +39,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;
         NSString *subject = [userInfo objectForKey:@"subject"];

--- a/REActivityViewController/REMapsActivity.m
+++ b/REActivityViewController/REMapsActivity.m
@@ -37,7 +37,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         [activityViewController dismissViewControllerAnimated:YES completion:nil];
         

--- a/REActivityViewController/REMessageActivity.m
+++ b/REActivityViewController/REMessageActivity.m
@@ -38,7 +38,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;
         NSString *text = [userInfo objectForKey:@"text"];

--- a/REActivityViewController/REPocketActivity.m
+++ b/REActivityViewController/REPocketActivity.m
@@ -38,7 +38,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         [activityViewController dismissViewControllerAnimated:YES completion:nil];
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;

--- a/REActivityViewController/REPrintActivity.m
+++ b/REActivityViewController/REPrintActivity.m
@@ -37,7 +37,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;
         [activityViewController dismissViewControllerAnimated:YES completion:^{

--- a/REActivityViewController/REReadabilityActivity.m
+++ b/REActivityViewController/REReadabilityActivity.m
@@ -42,7 +42,7 @@
     
     _consumerKey = consumerKey;
     _consumerSecret = consumerSecret;
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;
         if (![[NSUserDefaults standardUserDefaults] objectForKey:@"REReadabilityActivity_Key"]) {
@@ -59,7 +59,7 @@
 
 - (void)showAuthDialogWithActivityViewController:(REActivityViewController *)activityViewController
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     
     UIViewController *presenter = activityViewController.presentingController;
     NSDictionary *userInfo = self.userInfo ? self.userInfo : activityViewController.userInfo;

--- a/REActivityViewController/RESafariActivity.m
+++ b/REActivityViewController/RESafariActivity.m
@@ -37,7 +37,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         [activityViewController dismissViewControllerAnimated:YES completion:nil];
         

--- a/REActivityViewController/RESaveToCameraRollActivity.m
+++ b/REActivityViewController/RESaveToCameraRollActivity.m
@@ -38,7 +38,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         [activityViewController dismissViewControllerAnimated:YES completion:nil];
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;

--- a/REActivityViewController/RETumblrActivity.m
+++ b/REActivityViewController/RETumblrActivity.m
@@ -42,7 +42,7 @@
     
     _consumerKey = consumerKey;
     _consumerSecret = consumerSecret;
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;
         if (![[NSUserDefaults standardUserDefaults] objectForKey:@"RETumblrActivity_Email"]) {
@@ -68,7 +68,7 @@
 
 - (void)showAuthDialogWithActivityViewController:(REActivityViewController *)activityViewController
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     UIViewController *presenter = activityViewController.presentingController;
     NSDictionary *userInfo = self.userInfo ? self.userInfo : activityViewController.userInfo;
     [activityViewController dismissViewControllerAnimated:YES completion:^{
@@ -138,7 +138,7 @@
 
 - (void)shareUserInfo:(NSDictionary *)userInfo client:(AFXAuthClient *)client
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     UIViewController *presenter = self.activityViewController.presentingController;
     
     NSString *text = [userInfo objectForKey:@"text"];

--- a/REActivityViewController/RETwitterActivity.m
+++ b/REActivityViewController/RETwitterActivity.m
@@ -38,7 +38,7 @@
     if (!self)
         return nil;
     
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         UIViewController *presenter = activityViewController.presentingController;
         NSDictionary *userInfo = weakSelf.userInfo ? weakSelf.userInfo : activityViewController.userInfo;

--- a/REActivityViewController/REVKActivity.m
+++ b/REActivityViewController/REVKActivity.m
@@ -39,7 +39,7 @@
         return nil;
     
     _clientId = clientId;
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     self.actionBlock = ^(REActivity *activity, REActivityViewController *activityViewController) {
         UIViewController *presenter = activityViewController.presentingController;
         [activityViewController dismissViewControllerAnimated:YES completion:^{
@@ -64,7 +64,7 @@
 
 - (void)share
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     
     UIViewController *presenter = self.activityViewController.presentingController;
     NSDictionary *userInfo = self.userInfo ? self.userInfo : self.activityViewController.userInfo;
@@ -182,7 +182,7 @@
 
 - (void)shareText:(NSString *)text image:(UIImage *)image
 {
-    __weak __typeof(&*self)weakSelf = self;
+    __typeof(&*self) __weak weakSelf = self;
     
     [self requestPhotoUploadURLWithSuccess:^(NSString *uploadURL) {
         [weakSelf uploadImage:image toURL:uploadURL success:^(NSString *hash, NSString *photo, NSString *server) {


### PR DESCRIPTION
http://developer.apple.com/library/mac/#releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html

 You should decorate variables correctly. When using qualifiers in an
object variable declaration, the correct format is:

ClassName \* qualifier variableName;

Other variants are technically incorrect but are “forgiven” by the
compiler. To understand the issue, see http://cdecl.org/.
