### PR TITLE
Fix Instapaper credential saving issue

### DIFF
--- a/REActivityViewController/REInstapaperActivity.m
+++ b/REActivityViewController/REInstapaperActivity.m
@@ -57,7 +57,9 @@
                     [weakSelf authenticateUsername:username password:password success:^{
                         [controller dismissViewControllerAnimated:YES completion:nil];
                         [[NSUserDefaults standardUserDefaults] setObject:username forKey:@"REInstapaperActivity_Username"];
-                        [SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:@"REInstapaperActivity" updateExisting:YES error:nil];
+                        if ([SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:@"REInstapaperActivity" updateExisting:YES error:nil]) {
+                            [[NSUserDefaults standardUserDefaults] synchronize];
+                        }
                         [weakSelf saveURL:[userInfo objectForKey:@"url"] title:[userInfo objectForKey:@"text"]];
                     } error:^{
                         [controller showLoginButton];


### PR DESCRIPTION
Previously, the user's Instapaper password was properly
being written to the keychain, but the username/email
was never being persisted (i.e. NSUserDefaults'
-synchronize method was never called).
