### PR TITLE
Fixed a crash when there's no valid mail account settings in the system.

### DIFF
--- a/REActivityViewController/REMailActivity.m
+++ b/REActivityViewController/REMailActivity.m
@@ -49,25 +49,27 @@
         
         [activityViewController dismissViewControllerAnimated:YES completion:^{
             MFMailComposeViewController *mailComposeViewController = [[MFMailComposeViewController alloc] init];
-            [REActivityDelegateObject sharedObject].controller = activityViewController.presentingController;
-            mailComposeViewController.mailComposeDelegate = [REActivityDelegateObject sharedObject];
-            
-            if (text && !url)
-                [mailComposeViewController setMessageBody:text isHTML:YES];
-            
-            if (!text && url)
-                [mailComposeViewController setMessageBody:url.absoluteString isHTML:YES];
-            
-            if (text && url)
-                [mailComposeViewController setMessageBody:[NSString stringWithFormat:@"%@ %@", text, url.absoluteString] isHTML:YES];
-            
-            if (image)
-                [mailComposeViewController addAttachmentData:UIImageJPEGRepresentation(image, 0.75f) mimeType:@"image/jpeg" fileName:@"photo.jpg"];
-            
-            if (subject)
-                [mailComposeViewController setSubject:subject];
-            
-            [activityViewController.presentingController presentViewController:mailComposeViewController animated:YES completion:nil];
+			if (mailComposeViewController) {
+				[REActivityDelegateObject sharedObject].controller = activityViewController.presentingController;
+				mailComposeViewController.mailComposeDelegate = [REActivityDelegateObject sharedObject];
+				
+				if (text && !url)
+					[mailComposeViewController setMessageBody:text isHTML:YES];
+				
+				if (!text && url)
+					[mailComposeViewController setMessageBody:url.absoluteString isHTML:YES];
+				
+				if (text && url)
+					[mailComposeViewController setMessageBody:[NSString stringWithFormat:@"%@ %@", text, url.absoluteString] isHTML:YES];
+				
+				if (image)
+					[mailComposeViewController addAttachmentData:UIImageJPEGRepresentation(image, 0.75f) mimeType:@"image/jpeg" fileName:@"photo.jpg"];
+				
+				if (subject)
+					[mailComposeViewController setSubject:subject];
+				
+				[activityViewController.presentingController presentViewController:mailComposeViewController animated:YES completion:nil];
+			}
         }];
     };
     


### PR DESCRIPTION
When there's no valid mail account settings available, the new instance of MFMailComposeViewController will be nil, causing a crash.
So I added a if clause there to make sure the new instance of MFMailComposeViewController is not nil.
