### PR TITLE
Prevents warnings caused by AFNetworking dependency

### DIFF
--- a/REActivityViewController.podspec
+++ b/REActivityViewController.podspec
@@ -25,4 +25,18 @@ Pod::Spec.new do |s|
   s.dependency 'SFHFKeychainUtils', '~> 0.0.1'
   s.dependency 'PocketAPI', '~> 1.0.2'
   s.dependency 'AFXAuthClient', '~> 1.0.5'
+  
+  s.prefix_header_contents = <<-EOS
+  #import <Availability.h>
+
+  #if __IPHONE_OS_VERSION_MIN_REQUIRED
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <MobileCoreServices/MobileCoreServices.h>
+    #import <Security/Security.h>
+  #else
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <CoreServices/CoreServices.h>
+    #import <Security/Security.h>
+  #endif
+EOS
 end


### PR DESCRIPTION
Currently I'm experiencing warnings due to the lack of MobileCoreServices and SystemConfiguration in the prefix file under the new cocoapods system. This commit resolves that issue.
